### PR TITLE
Better exception handling

### DIFF
--- a/lib/twofishes/errors.rb
+++ b/lib/twofishes/errors.rb
@@ -1,6 +1,24 @@
 module Twofishes
+  BaseError = Class.new(StandardError)
+  InvalidResponseError = Class.new(BaseError)
 
-  class InvalidResponseError < StandardError
+  class ServerInternalError < InvalidResponseError
+    attr_reader :original_exception, :original_backtrace
+
+    def initialize(message = nil, original_exception = nil, original_backtrace = [])
+      super(message)
+      @original_exception = original_exception
+      @original_backtrace = original_backtrace
+      if String === @original_backtrace
+        @original_backtrace = @original_backtrace.each_line.map(&:strip).reject(&:empty?)
+      end
+    end
+
+    def message
+      "#{super} (#{original_exception})"
+    end
   end
 
+  UrlQueryError = Class.new(ServerInternalError)
+  WrongParamsError = Class.new(ServerInternalError)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,14 +6,17 @@ require 'minitest/autorun'
 require 'minitest/unit'
 require 'minitest/pride'
 require 'mocha/mini_test'
-require 'fakeweb'
+require 'webmock/minitest'
 
-FakeWeb.allow_net_connect = /^https:\/\/codeclimate\.com/
+WebMock.disable_net_connect!(:allow => "codeclimate.com")
 
 class MiniTest::Spec
 
   before do
-    FakeWeb.clean_registry
+    WebMock.reset!
   end
 
+  def mock_response(status, body)
+    stub_request(:get, %r{localhost:8081}).to_return(:status => status, :body => body.to_json, :headers => {'Content-Type' => 'application/json'})
+  end
 end

--- a/test/twofishes/client_test.rb
+++ b/test/twofishes/client_test.rb
@@ -3,23 +3,27 @@ require 'test_helper'
 describe Twofishes::Client do
 
   it "should geocode" do
-    FakeWeb.register_uri(:get, 'http://localhost:8081/?query=zurich', :status => 200, :body => '{}')
-    Twofishes::Client.geocode('zurich')
+    mock_response(200, interpretations: [])
+
+    Twofishes::Client.geocode('Zurich')
   end
 
   it "should reverse geocode" do
-    FakeWeb.register_uri(:get, 'http://localhost:8081/?ll=0%2C0', :status => 200, :body => '{}')
+    mock_response(200, interpretations: [])
+
     Twofishes::Client.reverse_geocode([0, 0])
   end
 
   it "should call api" do
-    FakeWeb.register_uri(:get, 'http://localhost:8081/?query=zurich', :status => 200, :body => '{}')
+    mock_response(200, interpretations: [])
+
     Twofishes::Client.call_api({query: 'zurich'})
   end
 
   it "should raise an error" do
-    FakeWeb.register_uri(:get, 'http://localhost:8081', :status => 500, :body => 'java.lang.NumberFormatException: For input string: ""')
-    assert_raises Twofishes::InvalidResponseError do
+    mock_response(500, exception: 'java.lang.NumberFormatException: For input string: ""')
+
+    assert_raises Twofishes::ServerInternalError do
       Twofishes::Client.call_api({})
     end
   end

--- a/test/twofishes/errors_test.rb
+++ b/test/twofishes/errors_test.rb
@@ -1,15 +1,64 @@
 require 'test_helper'
 
-describe Twofishes::InvalidResponseError do
+describe Twofishes::BaseError do
 
   it "should raise InvalidResponseError" do
+    mock_response(500, {})
+
     assert_raises Twofishes::InvalidResponseError do
-      raise Twofishes::InvalidResponseError, 'test'
+      Twofishes::Client.geocode("Zurich")
     end
   end
 
-  it "should be a StandardError" do
-    Twofishes::InvalidResponseError.new.is_a?(StandardError)
+  it "should raise ServerInternalError" do
+    mock_response(500, {exception: "java.lang.Exception: too many tokens"})
+
+    assert_raises Twofishes::ServerInternalError do
+      Twofishes::Client.geocode("Zurich")
+    end
+  end
+
+  it "should wrap original java exception" do
+    mock_response(500, exception: "java.lang.Exception: too many tokens", stacktrace: "com.foursquare.twofishes.QueryParser.parseQueryTokens(QueryParser.scala:52)\ncom.foursquare.twofishes.QueryParser.parseQuery(QueryParser.scala:22)\n")
+
+    begin
+      Twofishes::Client.geocode("Zurich")
+    rescue => ex
+      assert_kind_of Twofishes::ServerInternalError, ex
+      assert_equal "too many tokens", ex.to_s
+      assert_equal "java.lang.Exception", ex.original_exception
+      assert_equal ["com.foursquare.twofishes.QueryParser.parseQueryTokens(QueryParser.scala:52)", "com.foursquare.twofishes.QueryParser.parseQuery(QueryParser.scala:22)"], ex.original_backtrace
+    end
+  end
+
+  it "should raise UrlQueryError" do
+    mock_response(500, {exception: "java.lang.Exception: don't support url queries"})
+
+    assert_raises Twofishes::UrlQueryError do
+      Twofishes::Client.geocode("http://google.com")
+    end
+  end
+
+  it "should raise WrongParamsError" do
+    mock_response(500, {exception: "java.lang.Exception: both bounds and ll+radius, can't pick"})
+
+    assert_raises Twofishes::WrongParamsError do
+      Twofishes::Client.call_api({})
+    end
+  end
+
+  it "should raise WrongParamsError" do
+    mock_response(500, {exception: "java.lang.Exception: no bounds or ll"})
+
+    assert_raises Twofishes::WrongParamsError do
+      Twofishes::Client.call_api({})
+    end
+  end
+
+  it "should be a Twofishes::Error" do
+    assert Twofishes::ServerInternalError.new.kind_of?(Twofishes::BaseError)
+    assert Twofishes::InvalidResponseError.new.kind_of?(Twofishes::BaseError)
+    assert Twofishes::BaseError.new.kind_of?(StandardError)
   end
 
 end

--- a/twofishes.gemspec
+++ b/twofishes.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "fakeweb"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "codeclimate-test-reporter"


### PR DESCRIPTION
Add some more descriptive exceptions. Wrap original java exceptions, present original message and backtrace.

Also, for development, change fakeweb to webmock. Fakeweb is outdated.
