### PR TITLE
Expose thrift connection_timeout setting

### DIFF
--- a/lib/twofishes/client.rb
+++ b/lib/twofishes/client.rb
@@ -38,7 +38,8 @@ module Twofishes
         Geocoder::Client,
         Twofishes.configuration.address,
         retries: Twofishes.configuration.retries,
-        timeout: Twofishes.configuration.timeout
+        timeout: Twofishes.configuration.timeout,
+        connect_timeout: Twofishes.configuration.connect_timeout
       )
     end
 

--- a/lib/twofishes/configuration.rb
+++ b/lib/twofishes/configuration.rb
@@ -2,13 +2,14 @@ module Twofishes
   class Configuration
     # @see https://github.com/thoughtbot/clearance/blob/master/lib/clearance/configuration.rb
 
-    attr_accessor :host, :port, :timeout, :retries
+    attr_accessor :host, :port, :timeout, :retries, :connect_timeout
 
     def initialize
       @host = '127.0.0.1'
       @port = 8080
       @timeout = 3
       @retries = 2
+      @connect_timeout = 0.5
     end
 
     def address

--- a/test/twofishes/configuration_test.rb
+++ b/test/twofishes/configuration_test.rb
@@ -19,6 +19,10 @@ describe Twofishes::Configuration do
     assert_equal 2, configuration.retries
   end
 
+  it 'should return default connect_timeout' do
+    assert_equal 0.5, configuration.connect_timeout
+  end
+
   it 'should reset configuration' do
     Twofishes.configure do |config|
       config.host = '127.0.0.1'
@@ -38,4 +42,14 @@ describe Twofishes::Configuration do
     assert_equal '127.0.0.1:9090', configuration.address
     Twofishes.reset_configuration
   end
+
+  it 'should configure connect_timeout' do
+    Twofishes.configure do |config|
+      config.connect_timeout = 0.9
+    end
+
+    assert_equal 0.9, configuration.connect_timeout
+    Twofishes.reset_configuration
+  end
+
 end


### PR DESCRIPTION
Thrift is extremely sensitive to connection timeouts, and defaults to just 100ms... We should expose the configuration option and set a slightly higher default, to prevent unexpected and badly explained 'No live servers' errors.
