### PR TITLE
Refactor GeocodeRequest to fix quality drop

### DIFF
--- a/lib/twofishes/geocode_request.rb
+++ b/lib/twofishes/geocode_request.rb
@@ -13,11 +13,11 @@ module Twofishes
       case ll
       when String
         lat, lng = ll.split(/\s*,\s*/)
-        GeocodePoint.new(lat: lat.to_f, lng: lng.to_f)
+        new_point(lat, lng)
       when Array
-        GeocodePoint.new(lat: ll[0].to_f, lng: ll[1].to_f)
+        new_point(ll[0], ll[1])
       when Hash
-        GeocodePoint.new(lat: ll[:lat].to_f, lng: ll[:lng].to_f)
+        new_point(ll[:lat], ll[:lng])
       else
         ll
       end
@@ -27,17 +27,11 @@ module Twofishes
       case bounds
       when String
         ne_lat, ne_lng, sw_lat, sw_lng = bounds.split(/\s*,\s*/)
-        ne = GeocodePoint.new(lat: ne_lat.to_f, lng: ne_lng.to_f)
-        sw = GeocodePoint.new(lat: sw_lat.to_f, lng: sw_lng.to_f)
-        GeocodeBoundingBox.new(ne: ne, sw: sw)
+        new_bounding_box(ne_lat, ne_lng, sw_lat, sw_lng)
       when Array
-        ne = GeocodePoint.new(lat: bounds[0].to_f, lng: bounds[1].to_f)
-        sw = GeocodePoint.new(lat: bounds[2].to_f, lng: bounds[3].to_f)
-        GeocodeBoundingBox.new(ne: ne, sw: sw)
+        new_bounding_box(bounds[0], bounds[1], bounds[2], bounds[3])
       when Hash
-        ne = GeocodePoint.new(lat: bounds[:ne_lat].to_f, lng: bounds[:ne_lng].to_f)
-        sw = GeocodePoint.new(lat: bounds[:sw_lat].to_f, lng: bounds[:sw_lng].to_f)
-        GeocodeBoundingBox.new(ne: ne, sw: sw)
+        new_bounding_box(bounds[:ne_lat], bounds[:ne_lng], bounds[:sw_lat], bounds[:sw_lng])
       else
         bounds
       end
@@ -63,6 +57,18 @@ module Twofishes
       end
 
       options
+    end
+
+    private
+
+    def new_bounding_box(ne_lat, ne_lng, sw_lat, sw_lng)
+      ne = GeocodePoint.new(lat: ne_lat.to_f, lng: ne_lng.to_f)
+      sw = GeocodePoint.new(lat: sw_lat.to_f, lng: sw_lng.to_f)
+      GeocodeBoundingBox.new(ne: ne, sw: sw)
+    end
+
+    def new_point(lat, lng)
+      GeocodePoint.new(lat: lat.to_f, lng: lng.to_f)
     end
   end
 end

--- a/lib/twofishes/geocode_request.rb
+++ b/lib/twofishes/geocode_request.rb
@@ -45,15 +45,6 @@ module Twofishes
       options[:responseIncludes] ||= options.delete(:includes)
       options[:autocompleteBias] ||= options.delete(:bias)
 
-      if options[:ll].kind_of? Hash
-        options[:ll][:lng] = options[:ll][:lon] if options[:ll][:lon]
-      end
-
-      if options[:bounds].kind_of? Hash
-        options[:bounds][:ne_lng] = options[:bounds][:ne_lon] if options[:bounds] and options[:bounds][:ne_lon]
-        options[:bounds][:sw_lng] = options[:bounds][:sw_lon] if options[:bounds] and options[:bounds][:sw_lon]
-      end
-
       options
     end
 

--- a/lib/twofishes/geocode_request.rb
+++ b/lib/twofishes/geocode_request.rb
@@ -38,14 +38,12 @@ module Twofishes
     end
 
     def substitute_aliases(options)
-      options = options.dup
+      options = Hash[options.map{|k,v| [k.to_s.camelize(:lower).to_sym,v] } ]
 
-      options[:maxInterpretations] ||= options.delete(:max_interpretations) || options.delete(:max)
-      options[:allowedSources] ||= options.delete(:allowed_sources) || options.delete(:sources)
-      options[:responseIncludes] ||= options.delete(:response_includes) || options.delete(:includes)
-      options[:woeHint] ||= options.delete(:woe_hint)
-      options[:woeRestrict] ||= options.delete(:woe_restrict)
-      options[:autocompleteBias] ||= options.delete(:autocomplete_bias) || options.delete(:bias)
+      options[:maxInterpretations] ||= options.delete(:max)
+      options[:allowedSources] ||= options.delete(:sources)
+      options[:responseIncludes] ||= options.delete(:includes)
+      options[:autocompleteBias] ||= options.delete(:bias)
 
       if options[:ll].kind_of? Hash
         options[:ll][:lng] = options[:ll][:lon] if options[:ll][:lon]

--- a/test/twofishes/geocode_request_test.rb
+++ b/test/twofishes/geocode_request_test.rb
@@ -55,12 +55,6 @@ describe Twofishes::GeocodeRequest do
     assert_equal -74.0, request.ll.lng
   end
 
-  it 'should accept an ll argument that is a hash with "lon"' do
-    request = Twofishes::GeocodeRequest.new(ll: {lon: -74.0, lat: 40.74})
-    assert_equal 40.74, request.ll.lat
-    assert_equal -74.0, request.ll.lng
-  end
-
   it 'should accept a bounds argument' do
     request = Twofishes::GeocodeRequest.new(bounds: GeocodeBoundingBox.new(ne: GeocodePoint.new(lat: 40.74, lng: -74.0), sw: GeocodePoint.new(lat: 40.70, lng: -73.9)))
     assert_equal 40.74, request.bounds.ne.lat


### PR DESCRIPTION
Removes complexity from the GeocodeRequest class. 
- Extracts similar code into separate private methods for `prepare_bounds` and `prepare_ll`.
- Drop alias from `lon` to `lat`. It's complex and even without it, we're still matching twofishes' api.
- Implicit camel case conversion. The options hash contains only few elements, this will not be much slower. 

closes #9 
